### PR TITLE
Fix: Resolve multi-user write permission issues in Samba server

### DIFF
--- a/init_users.sh
+++ b/init_users.sh
@@ -54,4 +54,20 @@ while IFS=':' read -r username password; do
     
 done < <(grep -E '^[^#\[].*:.*' /etc/samba/users.conf)
 
+# Set proper ownership for each user's directory
+echo "Setting proper ownership for user directories..."
+while read -r line; do
+    # Look for share section headers [sharename]
+    if [[ $line =~ ^\[([^]]+)\]$ ]]; then
+        share_name="${BASH_REMATCH[1]}"
+        share_dir="/mount/storage/$share_name"
+        
+        if [ -d "$share_dir" ] && id "$share_name" &>/dev/null; then
+            echo "Setting ownership for $share_dir to $share_name:$share_name"
+            chown -R "$share_name:$share_name" "$share_dir"
+            chmod -R 775 "$share_dir"
+        fi
+    fi
+done < /etc/samba/users.conf
+
 echo "User and directory initialization complete."

--- a/start_samba.sh
+++ b/start_samba.sh
@@ -11,11 +11,6 @@ echo "Using HOST_UID=$HOST_UID and HOST_GID=$HOST_GID"
 # Initialize users
 /init_users.sh
 
-# Set proper permissions for storage directory
-# Use host user/group IDs for better compatibility
-chown -R $HOST_UID:$HOST_GID /mount/storage
-chmod -R 775 /mount/storage
-
 # Create log directory
 mkdir -p /var/log/samba
 


### PR DESCRIPTION
Fix: Resolve multi-user write permission issues in Samba server

Problem:

Only the first connected user could write to shares
All directories were owned by the same UID (1000:1000)
Subsequent users were denied write access
Root Cause:

start_samba.sh was overriding per-user ownership with HOST_UID:HOST_GID
Missing force user/group configuration in share definitions
Users.conf had example users instead of actual users
Solution:

Removed problematic chown -R $HOST_UID:$HOST_GID /mount/storage from start_samba.sh
Added proper per-user directory ownership logic in init_users.sh
Updated users.conf with real users (abhay, auraml, neuralzome, etc.)
Added force user/group settings to ensure proper file ownership
Each user now gets unique UID (2000+) with correct directory ownership
Result:

All users can now write to their respective directories simultaneously
Proper access control: users cannot access each other's directories
Admin user maintains access to all directories
File ownership correctly reflects the creating user