### PR TITLE
Fix Docker build on PRs

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -10,9 +10,10 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 2 * * 0'  # Every Sunday at 2 AM UTC
+    - cron: '0 2 * * 0' # Every Sunday at 2 AM UTC
 
 env:
+  ORG: filedash
   IMAGE_NAME: samba
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          images: ${{ secrets.DOCKERHUB_USERNAME || 'testuser' }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -79,6 +80,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME || 'testuser' }}/${{ env.IMAGE_NAME }}
           short-description: 'A containerized Samba file server solution with multi-user support and easy deployment'
           readme-filepath: ./README.md


### PR DESCRIPTION
This pull request updates the Docker build and push workflow to improve its robustness and flexibility, especially in handling DockerHub credentials. The main changes ensure that the workflow can fall back to a default DockerHub username if the secret is not set, and introduce a new environment variable for organization.

**Workflow improvements:**

* Added a new environment variable `ORG` set to `filedash` to the workflow environment for potential future use.

**Credential handling and fallback logic:**

* Updated the `images` and `repository` fields in the Docker metadata and publish steps to use `${{ secrets.DOCKERHUB_USERNAME || 'testuser' }}`. This provides a fallback to `'testuser'` if the DockerHub username secret is not set, improving workflow reliability. [[1]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L47-R48) [[2]](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10L82-R83)…e proper environment variable usage